### PR TITLE
Fix migrate.zsh crash when Zinit is not installed

### DIFF
--- a/migrate.zsh
+++ b/migrate.zsh
@@ -75,6 +75,9 @@ for d in "${ZSH_CUSTOM:-$HOME/.oh-my-zsh/custom}/themes/powerlevel10k" \
 done
 
 # Zinit / Zplugin
+# Declare ZINIT as associative array if not already set, so the
+# ${ZINIT[PLUGINS_DIR]:-...} fallback works under nounset (set -u).
+(( ${+ZINIT} )) || typeset -A ZINIT
 for d in ~/.zinit/plugins/romkatv---powerlevel10k \
          ~/.local/share/zinit/plugins/romkatv---powerlevel10k \
          "${ZINIT[PLUGINS_DIR]:-/dev/null}/romkatv---powerlevel10k" \


### PR DESCRIPTION
## Summary
  - migrate.zsh fails with `PLUGINS_DIR: parameter not set` on systems without Zinit
  - The script uses `set -u` (nounset), which causes `${ZINIT[PLUGINS_DIR]:-/dev/null}` to error when the `ZINIT` associative array is undeclared
  - Fix: declare `ZINIT` as an associative array if not already set, so the `:-` fallback works as intended

  ## Steps to reproduce
  ```zsh
  zsh <(curl -fsSL https://raw.githubusercontent.com/quantumnic/powerlevel10k/master/migrate.zsh)
  ```
