### PR TITLE
Fix gitstatus build failure with Apple Clang 17 (Xcode 16+)

### DIFF
--- a/gitstatus/build
+++ b/gitstatus/build
@@ -272,8 +272,9 @@ case "$gitstatus_kernel" in
       gitstatus_cxxflags="$gitstatus_cxxflags -I"$brew_prefix"/opt/libiconv/include"
     fi
     libgit2_cmake_flags="$libgit2_cmake_flags -DUSE_ICONV=ON"
-    gitstatus_ldlibs="$gitstatus_ldlibs -liconv"
+    gitstatus_ldlibs="$gitstatus_ldlibs -liconv -lz"
     gitstatus_ldflags="$gitstatus_ldflags -L${workdir}/lib"
+    libgit2_cmake_flags="$libgit2_cmake_flags -DUSE_BUNDLED_ZLIB=OFF"
     libgit2_cmake_flags="$libgit2_cmake_flags -DENABLE_REPRODUCIBLE_BUILDS=OFF"
   ;;
   msys*|mingw*)


### PR DESCRIPTION
Apple Clang 17 predefines TARGET_OS_MAC=1, which activates an ancient classic Mac OS code path in the bundled zlib. The fdopen macro replaces the system _stdio.h declaration of fdopen() with NULL, producing a parse error.

Error:
```
  _stdio.h:322:7: error: expected identifier or '('
    FILE *fdopen(int, const char *) ...

  zutil.h:140:33: note: expanded from macro 'fdopen'
    #define fdopen(fd,mode) NULL /* No fdopen() */
```

Fix: use system zlib instead of the bundled one.

  - Add -lz to gitstatus_ldlibs to link against system zlib
  - Add -DUSE_BUNDLED_ZLIB=OFF to libgit2 cmake flags