### PR TITLE
fix: reference to maintainer

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,7 +2,7 @@
 
 ## Current Maintainers
 
-- **Nicola Spieser** ([@redbasecap-buiss](https://github.com/redbasecap-buiss))
+- **Nicola Spieser** ([@quantumnic](https://github.com/quantumnic))
 
 ## Original Author
 


### PR DESCRIPTION
References to ~~[@**redbasecap-buiss**](https://github.com/redbasecap-buiss)~~:

**Broken and replaced to fix #20:**

https://github.com/quantumnic/powerlevel10k/blob/9db78019d0b68080597377ef78743f2854a08705/MAINTAINERS.md?plain=1#L5

**Working:**

https://github.com/quantumnic/powerlevel10k/blob/9db78019d0b68080597377ef78743f2854a08705/CHANGELOG.md?plain=1#L180-L185

