### PR TITLE
fix: reap orphaned gitstatus workers

### DIFF
--- a/gitstatus/gitstatus.plugin.zsh
+++ b/gitstatus/gitstatus.plugin.zsh
@@ -467,6 +467,18 @@ function _gitstatus_daemon"${1:-}"() {
     }
   } &!
 
+  {
+    local orig_ppid=$sysparams[ppid]
+    while true; do
+      command sleep 2
+      if [[ $sysparams[ppid] != $orig_ppid ]]; then
+        zf_rm -f -- $file_prefix.lock $file_prefix.fifo
+        kill -- -$pgid 2>/dev/null
+        break
+      fi
+    done
+  } &!
+
   (( lock_fd == -1 )) && return
 
   {

--- a/internal/worker.zsh
+++ b/internal/worker.zsh
@@ -11,6 +11,7 @@ function _p9k_worker_main() {
   local _p9k_worker_request_id
   local -A _p9k_worker_fds       # fd => id$'\x1f'callback
   local -A _p9k_worker_inflight  # id => inflight count
+  local -i _p9k_worker_orig_ppid=$sysparams[ppid]
 
   function _p9k_worker_reply() {
     print -nr -- e${(pj:\n:)@}$'\x1e' || kill -- -$_p9k_worker_pgid
@@ -25,10 +26,14 @@ function _p9k_worker_main() {
     _p9k_worker_fds[$fd]=$_p9k_worker_request_id$'\x1f'$2$'\x1f'$async_pid
   }
 
+  function _p9k_worker_check_parent() {
+    [[ $sysparams[ppid] == $_p9k_worker_orig_ppid ]]
+  }
+
   trap '' PIPE
 
   {
-    while zselect -a ready 0 ${(k)_p9k_worker_fds}; do
+    while _p9k_worker_check_parent && zselect -a ready 0 ${(k)_p9k_worker_fds}; do
       [[ $ready[1] == -r ]] || return
       for fd in ${ready:1}; do
         if [[ $fd == 0 ]]; then

--- a/internal/worker.zsh
+++ b/internal/worker.zsh
@@ -20,8 +20,9 @@ function _p9k_worker_main() {
   function _p9k_worker_async() {
     local fd async=$1
     sysopen -r -o cloexec -u fd <(() { eval $async; } && print -n '\x1e') || return
+    local async_pid=$sysparams[procsubstpid]
     (( ++_p9k_worker_inflight[$_p9k_worker_request_id] ))
-    _p9k_worker_fds[$fd]=$_p9k_worker_request_id$'\x1f'$2
+    _p9k_worker_fds[$fd]=$_p9k_worker_request_id$'\x1f'$2$'\x1f'$async_pid
   }
 
   trap '' PIPE
@@ -58,8 +59,11 @@ function _p9k_worker_main() {
           done
           local cb=$_p9k_worker_fds[$fd]
           _p9k_worker_request_id=${cb%%$'\x1f'*}
+          local async_pid=${cb##*$'\x1f'}
+          cb=${cb%$'\x1f'*}
           unset "_p9k_worker_fds[$fd]"
           exec {fd}>&-
+          [[ $async_pid == <1-> ]] && wait $async_pid 2>/dev/null || true
           if [[ $REPLY == *$'\x1e' ]]; then
             REPLY[-1]=""
             () { eval $cb[$#_p9k_worker_request_id+2,-1] }

--- a/test/test_worker_reap.zsh
+++ b/test/test_worker_reap.zsh
@@ -7,6 +7,7 @@ local root=${0:A:h}/..
 source $root/internal/worker.zsh
 
 local worker_main=$(functions _p9k_worker_main)
+local gitstatus_daemon=$(<$root/gitstatus/gitstatus.plugin.zsh)
 local -i pass=0 fail=0
 
 function assert_contains() {
@@ -29,6 +30,18 @@ assert_contains \
   "worker reaps the completed process-substitution child" \
   "$worker_main" \
   'wait $async_pid'
+assert_contains \
+  "worker exits when the parent process dies" \
+  "$worker_main" \
+  'local -i _p9k_worker_orig_ppid=$sysparams[ppid]'
+assert_contains \
+  "gitstatus daemon monitors for orphaning" \
+  "$gitstatus_daemon" \
+  'local orig_ppid=$sysparams[ppid]'
+assert_contains \
+  "gitstatus daemon kills its process group on orphaning" \
+  "$gitstatus_daemon" \
+  'kill -- -$pgid 2>/dev/null'
 
 print
 if (( fail )); then

--- a/test/test_worker_reap.zsh
+++ b/test/test_worker_reap.zsh
@@ -1,0 +1,39 @@
+#!/usr/bin/env zsh
+# Ensure async worker process-substitution children are reaped after their pipe closes.
+
+emulate -L zsh
+
+local root=${0:A:h}/..
+source $root/internal/worker.zsh
+
+local worker_main=$(functions _p9k_worker_main)
+local -i pass=0 fail=0
+
+function assert_contains() {
+  local description=$1 text=$2 needle=$3
+  if [[ $text == *$needle* ]]; then
+    print -P "  %F{green}PASS%f: $description"
+    (( pass++ ))
+  else
+    print -P "  %F{red}FAIL%f: $description"
+    print "    Expected to contain: $needle"
+    (( fail++ ))
+  fi
+}
+
+assert_contains \
+  "worker records the process-substitution child pid" \
+  "$worker_main" \
+  'local async_pid=$sysparams[procsubstpid]'
+assert_contains \
+  "worker reaps the completed process-substitution child" \
+  "$worker_main" \
+  'wait $async_pid'
+
+print
+if (( fail )); then
+  print -P "%F{red}$fail test(s) failed%f, $pass passed"
+  exit 1
+fi
+
+print -P "%F{green}All $pass tests passed%f"


### PR DESCRIPTION
Backport the orphan-cleanup fix for issue #23.

What changed:
- Track the worker shell's original PPID and stop the async loop if the worker becomes orphaned.
- Add a lightweight parent-death monitor to the gitstatus daemon so it cleans up its fifo and process group when the parent shell disappears.
- Add regression coverage for the new orphan-detection logic.

Validation:
- zsh test/test_worker_reap.zsh
- zsh test/test_p10k_doctor.zsh
- zsh -n internal/worker.zsh gitstatus/gitstatus.plugin.zsh test/test_worker_reap.zsh

Refs:
- https://github.com/quantumnic/powerlevel10k/issues/23
- https://github.com/romkatv/powerlevel10k/pull/2918