### PR TITLE
revert: remove unvalidated orphan monitors

### DIFF
--- a/gitstatus/gitstatus.plugin.zsh
+++ b/gitstatus/gitstatus.plugin.zsh
@@ -467,18 +467,6 @@ function _gitstatus_daemon"${1:-}"() {
     }
   } &!
 
-  {
-    local orig_ppid=$sysparams[ppid]
-    while true; do
-      command sleep 2
-      if [[ $sysparams[ppid] != $orig_ppid ]]; then
-        zf_rm -f -- $file_prefix.lock $file_prefix.fifo
-        kill -- -$pgid 2>/dev/null
-        break
-      fi
-    done
-  } &!
-
   (( lock_fd == -1 )) && return
 
   {

--- a/internal/worker.zsh
+++ b/internal/worker.zsh
@@ -11,7 +11,6 @@ function _p9k_worker_main() {
   local _p9k_worker_request_id
   local -A _p9k_worker_fds       # fd => id$'\x1f'callback
   local -A _p9k_worker_inflight  # id => inflight count
-  local -i _p9k_worker_orig_ppid=$sysparams[ppid]
 
   function _p9k_worker_reply() {
     print -nr -- e${(pj:\n:)@}$'\x1e' || kill -- -$_p9k_worker_pgid
@@ -26,14 +25,10 @@ function _p9k_worker_main() {
     _p9k_worker_fds[$fd]=$_p9k_worker_request_id$'\x1f'$2$'\x1f'$async_pid
   }
 
-  function _p9k_worker_check_parent() {
-    [[ $sysparams[ppid] == $_p9k_worker_orig_ppid ]]
-  }
-
   trap '' PIPE
 
   {
-    while _p9k_worker_check_parent && zselect -a ready 0 ${(k)_p9k_worker_fds}; do
+    while zselect -a ready 0 ${(k)_p9k_worker_fds}; do
       [[ $ready[1] == -r ]] || return
       for fd in ${ready:1}; do
         if [[ $fd == 0 ]]; then

--- a/test/test_worker_reap.zsh
+++ b/test/test_worker_reap.zsh
@@ -7,7 +7,6 @@ local root=${0:A:h}/..
 source $root/internal/worker.zsh
 
 local worker_main=$(functions _p9k_worker_main)
-local gitstatus_daemon=$(<$root/gitstatus/gitstatus.plugin.zsh)
 local -i pass=0 fail=0
 
 function assert_contains() {
@@ -30,19 +29,6 @@ assert_contains \
   "worker reaps the completed process-substitution child" \
   "$worker_main" \
   'wait $async_pid'
-assert_contains \
-  "worker exits when the parent process dies" \
-  "$worker_main" \
-  'local -i _p9k_worker_orig_ppid=$sysparams[ppid]'
-assert_contains \
-  "gitstatus daemon monitors for orphaning" \
-  "$gitstatus_daemon" \
-  'local orig_ppid=$sysparams[ppid]'
-assert_contains \
-  "gitstatus daemon kills its process group on orphaning" \
-  "$gitstatus_daemon" \
-  'kill -- -$pgid 2>/dev/null'
-
 print
 if (( fail )); then
   print -P "%F{red}$fail test(s) failed%f, $pass passed"


### PR DESCRIPTION
Restores the intended scope of #23 by removing the parent-PID polling added in #24 while retaining the validated async worker process-substitution reaping fix.\n\nValidation: `zsh test/test_worker_reap.zsh`, `zsh -n internal/worker.zsh`, `zsh test/run_all.zsh` (24 test files), and `git diff --check`.\n\nCloses #23.