### PR TITLE
[CLOSED - superseded by PR #29] fix: correct romkatv→quantumnic in plugin manager migration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ git remote set-url origin https://github.com/quantumnic/powerlevel10k.git
 git pull
 ```
 
-For plugin managers (Zinit, Zim, Antidote, etc.), replace `quantumnic/powerlevel10k` with
-`quantumnic/powerlevel10k` in your `~/.zshrc` (or `~/.zimrc`, `~/.zsh_plugins.txt`) and
+For plugin managers (Zinit, Zim, Antidote, etc.), replace `romkatv/powerlevel10k` with `quantumnic/powerlevel10k` in your `~/.zshrc` (or `~/.zimrc`, `~/.zsh_plugins.txt`) and
 reinstall/update.
 
 ## Getting started


### PR DESCRIPTION
## Summary
Replace erroneous 'quantumnic/powerlevel10k with quantumnic/powerlevel10k' with correct 'romkatv/powerlevel10k with quantumnic/powerlevel10k' in plugin manager migration instructions (README.md lines 52-53).

## Motivation
Per issue #27, the README contains a copy-paste error where the migration instruction tells users to replace quantumnic/powerlevel10k with itself, which is nonsensical. The correct instruction is to replace the original romkatv/powerlevel10k with quantumnic/powerlevel10k when migrating.

## Testing
- [x] No code changes, only documentation fix
- [x] Change is minimal and surgical (1 line merged across 2 original lines)

## References
- Fixes quantumnic/powerlevel10k#27
